### PR TITLE
Fixes for device uplink counters

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -79,6 +79,10 @@ type DeviceStats struct {
 	Uplink     *WiredStats
 }
 
+func (s *DeviceStats) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
 // WirelessStats contains wireless device network activity statistics.
 type WirelessStats struct {
 	ReceiveBytes    float64
@@ -88,12 +92,20 @@ type WirelessStats struct {
 	TransmitPackets float64
 }
 
+func (s *WirelessStats) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
 // WiredStats contains wired device network activity statistics.
 type WiredStats struct {
 	ReceiveBytes    float64
 	ReceivePackets  float64
 	TransmitBytes   float64
 	TransmitPackets float64
+}
+
+func (s *WiredStats) String() string {
+	return fmt.Sprintf("%v", *s)
 }
 
 const (
@@ -197,10 +209,10 @@ func (d *Device) UnmarshalJSON(b []byte) error {
 				TransmitPackets: dev.Stat.UserTxPackets,
 			},
 			Uplink: &WiredStats{
-				ReceiveBytes:    dev.Stat.UplinkRxBytes,
-				ReceivePackets:  dev.Stat.UplinkRxPackets,
-				TransmitBytes:   dev.Stat.UplinkTxBytes,
-				TransmitPackets: dev.Stat.UplinkTxPackets,
+				ReceiveBytes:    dev.Uplink.RxBytes,
+				ReceivePackets:  dev.Uplink.RxPackets,
+				TransmitBytes:   dev.Uplink.TxBytes,
+				TransmitPackets: dev.Uplink.TxPackets,
 			},
 		},
 	}
@@ -281,10 +293,6 @@ type device struct {
 		TxBytes          float64 `json:"tx_bytes"`
 		TxDropped        float64 `json:"tx_dropped"`
 		TxPackets        float64 `json:"tx_packets"`
-		UplinkRxBytes    float64 `json:"uplink-rx_bytes"`
-		UplinkRxPackets  float64 `json:"uplink-rx_packets"`
-		UplinkTxBytes    float64 `json:"uplink-tx_bytes"`
-		UplinkTxPackets  float64 `json:"uplink-tx_packets"`
 		UserNgRxBytes    float64 `json:"user-ng-rx_bytes"`
 		UserNgRxPackets  float64 `json:"user-ng-rx_packets"`
 		UserNgTxBytes    float64 `json:"user-ng-tx_bytes"`
@@ -296,6 +304,15 @@ type device struct {
 		UserTxDropped    float64 `json:"user-tx_dropped"`
 		UserTxPackets    float64 `json:"user-tx_packets"`
 	} `json:"stat"`
+	Uplink struct {
+		RxBytes   float64 `json:"rx_bytes"`
+		RxPackets float64 `json:"rx_packets"`
+		RxErrors  float64 `json:"rx_errors"`
+		TxBytes   float64 `json:"tx_bytes"`
+		TxPackets float64 `json:"tx_packets"`
+		TxErrors  float64 `json:"tx_errors"`
+		Type      string  `json:"type"`
+	} `json:"uplink"`
 	State         int           `json:"state"`
 	TxBytes       float64       `json:"tx_bytes"`
 	Type          string        `json:"type"`

--- a/devices_test.go
+++ b/devices_test.go
@@ -158,13 +158,30 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 		"user-rx_packets": 4,
 		"user-tx_bytes": 20,
 		"user-tx_dropped": 1,
-		"user-tx_packets": 1,
-		"uplink-rx_bytes": 80,
-		"uplink-rx_packets": 4,
-		"uplink-tx_bytes": 20,
-		"uplink-tx_packets": 1
+		"user-tx_packets": 1
 	},
-	"uptime": "61",
+	"uplink": {  
+		"full_duplex": true,
+		"ip": "0.0.0.0",
+		"mac": "de:ad:be:ef:00:00",
+		"max_speed": 1000,
+		"name": "eth0",
+		"netmask": "0.0.0.0",
+		"num_port": 2,
+		"rx_bytes": 81,
+		"rx_dropped": 11023,
+		"rx_errors": 0,
+		"rx_multicast": 0,
+		"rx_packets": 5,
+		"speed": 1000,
+		"tx_bytes": 21,
+		"tx_dropped": 0,
+		"tx_errors": 0,
+		"tx_packets": 2,
+		"type": "wire",
+		"up": true
+	},
+	"uptime": 61,
 	"version": "1.0.0"
 }
 `)),
@@ -233,10 +250,10 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 						TransmitPackets: 1,
 					},
 					Uplink: &WiredStats{
-						ReceiveBytes:    80,
-						ReceivePackets:  4,
-						TransmitBytes:   20,
-						TransmitPackets: 1,
+						ReceiveBytes:    81,
+						ReceivePackets:  5,
+						TransmitBytes:   21,
+						TransmitPackets: 2,
 					},
 				},
 				Uptime:  61 * time.Second,
@@ -253,8 +270,11 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
 					want, got)
 			}
-			if err != nil {
+			if tt.err != nil {
 				return
+			}
+			if err != nil {
+				t.Fatalf("Error parsing json: %v", err)
 			}
 
 			if want, got := tt.d, d; !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
Fixing devices_test: the most important test had stopped working due to short-circuiting if err is not nil.

Getting uplink stats from the new place where they exist, rather than the now-nonexistent uplink prefix.