### PR TITLE
[NEEDS TESTING / WIP]: Upgrade for 5.7.20

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -156,24 +156,21 @@ func (d *Device) UnmarshalJSON(b []byte) error {
 			Name:               rt.Name,
 		}
 
-		// 5GHz and 2.4GHz station counts appear in different keys for
-		// different radio types, so we check the radio type first to determine
-		// where the correct radio statistics are
+		for _, v := range dev.RadioTableStats {
+			if v.Name == rt.Name {
+				r.Stats = &RadioStationsStats{
+					NumberStations:      v.NumSta,
+					NumberUserStations:  v.UserNumSta,
+					NumberGuestStations: v.GuestNumSta,
+				}
+			}
+		}
+
 		switch rt.Radio {
 		case radioNA:
 			r.Radio = radio5GHz
-			r.Stats = &RadioStationsStats{
-				NumberStations:      dev.NaNumSta,
-				NumberUserStations:  dev.NaUserNumSta,
-				NumberGuestStations: dev.NaGuestNumSta,
-			}
 		case radioNG:
 			r.Radio = radio24GHz
-			r.Stats = &RadioStationsStats{
-				NumberStations:      dev.NgNumSta,
-				NumberUserStations:  dev.NgUserNumSta,
-				NumberGuestStations: dev.NgGuestNumSta,
-			}
 		}
 
 		radios = append(radios, r)
@@ -208,6 +205,13 @@ func (d *Device) UnmarshalJSON(b []byte) error {
 				TransmitDropped: dev.Stat.UserTxDropped,
 				TransmitPackets: dev.Stat.UserTxPackets,
 			},
+			Guest: &WirelessStats{
+				ReceiveBytes:    dev.Stat.GuestRxBytes,
+				ReceivePackets:  dev.Stat.GuestRxPackets,
+				TransmitBytes:   dev.Stat.GuestTxBytes,
+				TransmitDropped: dev.Stat.GuestTxDropped,
+				TransmitPackets: dev.Stat.GuestTxPackets,
+			},
 			Uplink: &WiredStats{
 				ReceiveBytes:    dev.Uplink.RxBytes,
 				ReceivePackets:  dev.Uplink.RxPackets,
@@ -238,24 +242,17 @@ type device struct {
 		Name    string `json:"name"`
 		NumPort int    `json:"num_port"`
 	} `json:"ethernet_table"`
-	GuestNumSta   int         `json:"guest-num_sta"`
-	HasSpeaker    bool        `json:"has_speaker"`
-	InformIP      string      `json:"inform_ip"`
-	InformURL     string      `json:"inform_url"`
-	IP            string      `json:"ip"`
-	LastSeen      int         `json:"last_seen"`
-	MAC           string      `json:"mac"`
-	Model         string      `json:"model"`
-	Name          string      `json:"name"`
-	NaGuestNumSta int         `json:"na-guest-num_sta"`
-	NaNumSta      int         `json:"na-num_sta"`
-	NaUserNumSta  int         `json:"na-user-num_sta"`
-	NgGuestNumSta int         `json:"ng-guest-num_sta"`
-	NgNumSta      int         `json:"ng-num_sta"`
-	NgUserNumSta  int         `json:"ng-user-num_sta"`
-	NumSta        int         `json:"num_sta"`
-	RadioNa       interface{} `json:"radio_na"`
-	RadioNg       struct {
+	GuestNumSta int    `json:"guest-num_sta"`
+	HasSpeaker  bool   `json:"has_speaker"`
+	InformIP    string `json:"inform_ip"`
+	InformURL   string `json:"inform_url"`
+	IP          string `json:"ip"`
+	LastSeen    int    `json:"last_seen"`
+	MAC         string `json:"mac"`
+	Model       string `json:"model"`
+	Name        string `json:"name"`
+	NumSta      int    `json:"num_sta"`
+	RadioNg     struct {
 		BuiltInAntennaGain int    `json:"builtin_ant_gain"`
 		BuiltInAntenna     bool   `json:"builtin_antenna"`
 		MaxTXPower         int    `json:"max_txpower"`
@@ -271,38 +268,47 @@ type device struct {
 		Name           string `json:"name"`
 		Radio          string `json:"radio"`
 	} `json:"radio_table"`
+	RadioTableStats []struct {
+		AstBeXmit   int         `json:"ast_be_xmit"`
+		AstCst      int         `json:"ast_cst"`
+		AstTxto     interface{} `json:"ast_txto"`
+		Channel     int         `json:"channel"`
+		CuSelfRx    int         `json:"cu_self_rx"`
+		CuSelfTx    int         `json:"cu_self_tx"`
+		CuTotal     int         `json:"cu_total"`
+		Extchannel  int         `json:"extchannel"`
+		Gain        int         `json:"gain"`
+		GuestNumSta int         `json:"guest-num_sta"`
+		Name        string      `json:"name"`
+		NumSta      int         `json:"num_sta"`
+		Radio       string      `json:"radio"`
+		State       string      `json:"state"`
+		TxPackets   int         `json:"tx_packets"`
+		TxPower     int         `json:"tx_power"`
+		TxRetries   int         `json:"tx_retries"`
+		UserNumSta  int         `json:"user-num_sta"`
+	} `json:"radio_table_stats"`
 	RxBytes float64 `json:"rx_bytes"`
 	Serial  string  `json:"serial,omitempty"`
 	SiteID  string  `json:"site_id"`
 	Stat    struct {
-		Bytes            float64 `json:"bytes"`
-		GuestNgTxBytes   float64 `json:"guest-ng-tx_bytes"`
-		GuestNgTxDropped float64 `json:"guest-ng-tx_dropped"`
-		GuestNgTxPackets float64 `json:"guest-ng-tx_packets"`
-		GuestTxBytes     float64 `json:"guest-tx_bytes"`
-		GuestTxDropped   float64 `json:"guest-tx_dropped"`
-		GuestTxPackets   float64 `json:"guest-tx_packets"`
-		Mac              string  `json:"mac"`
-		NgRxBytes        float64 `json:"ng-rx_bytes"`
-		NgRxPackets      float64 `json:"ng-rx_packets"`
-		NgTxBytes        float64 `json:"ng-tx_bytes"`
-		NgTxDropped      float64 `json:"ng-tx_dropped"`
-		NgTxPackets      float64 `json:"ng-tx_packets"`
-		RxBytes          float64 `json:"rx_bytes"`
-		RxPackets        float64 `json:"rx_packets"`
-		TxBytes          float64 `json:"tx_bytes"`
-		TxDropped        float64 `json:"tx_dropped"`
-		TxPackets        float64 `json:"tx_packets"`
-		UserNgRxBytes    float64 `json:"user-ng-rx_bytes"`
-		UserNgRxPackets  float64 `json:"user-ng-rx_packets"`
-		UserNgTxBytes    float64 `json:"user-ng-tx_bytes"`
-		UserNgTxDropped  float64 `json:"user-ng-tx_dropped"`
-		UserNgTxPackets  float64 `json:"user-ng-tx_packets"`
-		UserRxBytes      float64 `json:"user-rx_bytes"`
-		UserRxPackets    float64 `json:"user-rx_packets"`
-		UserTxBytes      float64 `json:"user-tx_bytes"`
-		UserTxDropped    float64 `json:"user-tx_dropped"`
-		UserTxPackets    float64 `json:"user-tx_packets"`
+		Bytes          float64 `json:"bytes"`
+		GuestRxBytes   float64 `json:"guest-rx_bytes"`
+		GuestRxPackets float64 `json:"guest-rx_packets"`
+		GuestTxBytes   float64 `json:"guest-tx_bytes"`
+		GuestTxDropped float64 `json:"guest-tx_dropped"`
+		GuestTxPackets float64 `json:"guest-tx_packets"`
+		Mac            string  `json:"mac"`
+		RxBytes        float64 `json:"rx_bytes"`
+		RxPackets      float64 `json:"rx_packets"`
+		TxBytes        float64 `json:"tx_bytes"`
+		TxDropped      float64 `json:"tx_dropped"`
+		TxPackets      float64 `json:"tx_packets"`
+		UserRxBytes    float64 `json:"user-rx_bytes"`
+		UserRxPackets  float64 `json:"user-rx_packets"`
+		UserTxBytes    float64 `json:"user-tx_bytes"`
+		UserTxDropped  float64 `json:"user-tx_dropped"`
+		UserTxPackets  float64 `json:"user-tx_packets"`
 	} `json:"stat"`
 	Uplink struct {
 		RxBytes   float64 `json:"rx_bytes"`

--- a/devices_test.go
+++ b/devices_test.go
@@ -33,6 +33,7 @@ func TestClientDevices(t *testing.T) {
 			All:    &WirelessStats{},
 			User:   &WirelessStats{},
 			Uplink: &WiredStats{},
+			Guest:  &WirelessStats{},
 		},
 	}
 
@@ -121,12 +122,6 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 			"name": "eth0"
 		}
 	],
-	"na-num_sta": 3,
-	"na-user-num_sta": 2,
-	"na-guest-num_sta": 1,
-	"ng-num_sta": 3,
-	"ng-user-num_sta": 2,
-	"ng-guest-num_sta": 1,
 	"radio_table": [
 		{
 			"builtin_ant_gain": 1,
@@ -145,22 +140,38 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 			"radio": "na"
 		}
 	],
+	"radio_table_stats": [{
+		"guest-num_sta": 1,
+		"name": "wlan0",
+		"num_sta": 3,
+		"user-num_sta": 2
+	}, {
+		"guest-num_sta": 1,
+		"name": "wlan1",
+		"num_sta": 3,
+		"user-num_sta": 2
+	}],
 	"serial": "deadbeef0123456789",
 	"site_id": "default",
 	"stat": {
+		"guest-rx_bytes": 101,
+		"guest-rx_packets": 5,
+		"guest-tx_bytes": 40,
+		"guest-tx_dropped": 7,
+		"guest-tx_packets": 9,
+		"user-rx_bytes": 80,
+		"user-rx_packets": 4,
+		"user-tx_bytes": 20,
+		"user-tx_dropped": 1,
+		"user-tx_packets": 1,
 		"bytes": 100,
 		"rx_bytes": 80,
 		"rx_packets": 4,
 		"tx_bytes": 20,
 		"tx_dropped": 1,
-		"tx_packets": 1,
-		"user-rx_bytes": 80,
-		"user-rx_packets": 4,
-		"user-tx_bytes": 20,
-		"user-tx_dropped": 1,
-		"user-tx_packets": 1
+		"tx_packets": 1
 	},
-	"uplink": {  
+	"uplink": {
 		"full_duplex": true,
 		"ip": "0.0.0.0",
 		"mac": "de:ad:be:ef:00:00",
@@ -254,6 +265,13 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 						ReceivePackets:  5,
 						TransmitBytes:   21,
 						TransmitPackets: 2,
+					},
+					Guest: &WirelessStats{
+						ReceiveBytes:    101,
+						ReceivePackets:  5,
+						TransmitBytes:   40,
+						TransmitDropped: 7,
+						TransmitPackets: 9,
 					},
 				},
 				Uptime:  61 * time.Second,


### PR DESCRIPTION
Hey @mdlayher! This is the only part of #7 that I've been able to track down as necessary so far, although I am only using this package indirectly through `unifi_exporter`, so there _may_ be more missing.

Overall, it looks like the big difference is that there is no longer a standardized set of keys for 2.4GHz and 5GHz networks directly in the stats key - instead, they're named after the radio on my instance running 5.7.20. Unfortunately, this makes those keys backwards incompatible _and_ difficult to use, given the nature of Go's JSON parsing and the lack of predictability (go figure).

I did some research and looked at other client libraries and there really isn't that much out there - go figure. I'd love to know if this is backwards compatible with 5.6.xx? I'd guess it is, but at this point I don't really have a way to test without standing up a whole new controller, etc.

I suspect that there's a myriad of devices and device configurations and that this code probably won't work for all of them - I have no idea what devices like the AP SHD and AP HD return - I can tell you that this works on my AP-AC-LR and my UAP-AC-M that I have at home.