### PR TITLE
Add device utilization stats

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -77,10 +77,23 @@ type DeviceStats struct {
 	Guest      *WirelessStats
 	User       *WirelessStats
 	Uplink     *WiredStats
+	System     *SystemStats
 }
 
 func (s *DeviceStats) String() string {
 	return fmt.Sprintf("%v", *s)
+}
+
+type SystemStats struct {
+	CpuPercentage float64
+	MemPercentage float64
+	Uptime        int
+	LoadAvg1      float64
+	LoadAvg15     float64
+	LoadAvg5      float64
+	MemBuffer     int64
+	MemTotal      int64
+	MemUsed       int64
 }
 
 // WirelessStats contains wireless device network activity statistics.
@@ -218,6 +231,17 @@ func (d *Device) UnmarshalJSON(b []byte) error {
 				TransmitBytes:   dev.Uplink.TxBytes,
 				TransmitPackets: dev.Uplink.TxPackets,
 			},
+			System: &SystemStats{
+				Uptime:        dev.SystemStats.Uptime,
+				CpuPercentage: dev.SystemStats.CpuPercentage,
+				MemPercentage: dev.SystemStats.MemPercentage,
+				LoadAvg1:      dev.SysStats.LoadAvg1,
+				LoadAvg15:     dev.SysStats.LoadAvg15,
+				LoadAvg5:      dev.SysStats.LoadAvg5,
+				MemBuffer:     dev.SysStats.MemBuffer,
+				MemTotal:      dev.SysStats.MemTotal,
+				MemUsed:       dev.SysStats.MemUsed,
+			},
 		},
 	}
 
@@ -332,4 +356,17 @@ type device struct {
 	XAuthkey      string        `json:"x_authkey"`
 	XFingerprint  string        `json:"x_fingerprint"`
 	XVwirekey     string        `json:"x_vwirekey"`
+	SystemStats   struct {
+		CpuPercentage float64 `json:"cpu,string"`
+		MemPercentage float64 `json:"mem,string"`
+		Uptime        int     `json:"uptime,string"`
+	} `json:"system-stats"`
+	SysStats struct {
+		LoadAvg1  float64 `json:"loadavg_1,string"`
+		LoadAvg15 float64 `json:"loadavg_15,string"`
+		LoadAvg5  float64 `json:"loadavg_5,string"`
+		MemBuffer int64   `json:"mem_buffer"`
+		MemTotal  int64   `json:"mem_total"`
+		MemUsed   int64   `json:"mem_used"`
+	} `json:"sys_stats"`
 }

--- a/devices_test.go
+++ b/devices_test.go
@@ -34,6 +34,7 @@ func TestClientDevices(t *testing.T) {
 			User:   &WirelessStats{},
 			Uplink: &WiredStats{},
 			Guest:  &WirelessStats{},
+			System: &SystemStats{},
 		},
 	}
 
@@ -193,7 +194,20 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 		"up": true
 	},
 	"uptime": 61,
-	"version": "1.0.0"
+	"version": "1.0.0",
+	"sys_stats": {
+        "loadavg_1": "1.48",
+        "loadavg_15": "1.57",
+        "loadavg_5": "1.58",
+        "mem_buffer": 0,
+        "mem_total": 262516736,
+        "mem_used": 168779776
+      },
+      "system-stats": {
+        "cpu": "55.7",
+        "mem": "64.3",
+        "uptime": "11622320"
+      }
 }
 `)),
 			d: &Device{
@@ -272,6 +286,17 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 						TransmitBytes:   40,
 						TransmitDropped: 7,
 						TransmitPackets: 9,
+					},
+					System: &SystemStats{
+						Uptime:        11622320,
+						CpuPercentage: 55.7,
+						MemPercentage: 64.3,
+						LoadAvg1:      1.48,
+						LoadAvg15:     1.57,
+						LoadAvg5:      1.58,
+						MemBuffer:     0,
+						MemTotal:      262516736,
+						MemUsed:       168779776,
 					},
 				},
 				Uptime:  61 * time.Second,


### PR DESCRIPTION
Add new system utilization stats:
- Uptime
- CpuPercentage
- MemPercentage
- LoadAvg1
- LoadAvg15
- LoadAvg5
- MemBuffer
- MemTotal
- MemUsed

Update tests to include new stats