### PR TITLE
Package unifi: Implement Device.String().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
 before_script:
   - go get -d ./...
 script:

--- a/devices.go
+++ b/devices.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -222,6 +223,20 @@ func (d *Device) UnmarshalJSON(b []byte) error {
 	}
 
 	return nil
+}
+
+func (d Device) String() string {
+	if d.Name != "" {
+		return d.Name
+	}
+	if d.Serial != "" {
+		if len(d.Serial) != 12 {
+			return d.Serial
+		}
+		s := strings.ToLower(d.Serial)
+		return strings.Join([]string{s[0:2], s[2:4], s[4:6], s[6:8], s[8:10], s[10:12]}, ":")
+	}
+	return d.ID
 }
 
 // A device is the raw structure of a Device returned from the UniFi Controller


### PR DESCRIPTION
Behaves like the Unifi UI, i.e. returns the device's name if set and the serial otherwise. If the serial has exactly 12 characters, it is formatted like a MAC address, again like the UI does.