### PR TITLE
Expose the device's state (connected or disconnected)

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -27,10 +27,22 @@ func (c *Client) Devices(siteName string) ([]*Device, error) {
 	return v.Devices, err
 }
 
+// DeviceState represents the state of the device (connected/disconnected)
+type DeviceState int
+
+const (
+	// DeviceDisconnected is the state for when a UniFi device is offline
+	DeviceDisconnected DeviceState = iota
+
+	// DeviceConnected is the state for when a UnifiDevice is online
+	DeviceConnected
+)
+
 // A Device is a Ubiquiti UniFi device, such as a UniFi access point.
 type Device struct {
 	ID        string
 	Adopted   bool
+	State     DeviceState
 	InformIP  net.IP
 	InformURL *url.URL
 	Model     string
@@ -179,6 +191,7 @@ func (d *Device) UnmarshalJSON(b []byte) error {
 	*d = Device{
 		ID:        dev.ID,
 		Adopted:   dev.Adopted,
+		State:     DeviceState(dev.State),
 		InformIP:  informIP,
 		InformURL: informURL,
 		Model:     dev.Model,

--- a/devices_test.go
+++ b/devices_test.go
@@ -116,6 +116,7 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 	"inform_url": "http://192.168.1.1:8080/inform",
 	"model": "uap1000",
 	"name": "AP",
+	"state": 1,
 	"ethernet_table": [
 		{
 			"mac": "de:ad:be:ef:de:ad",
@@ -199,6 +200,7 @@ func TestDeviceUnmarshalJSON(t *testing.T) {
 			d: &Device{
 				ID:       "abcdef1234567890",
 				Adopted:  true,
+				State:    DeviceConnected,
 				InformIP: net.IPv4(192, 168, 1, 1),
 				InformURL: func() *url.URL {
 					u, err := url.Parse("http://192.168.1.1:8080/inform")


### PR DESCRIPTION
If a UniFi device is offline, whether intentionally or accidentally, this
currently breaks the `unifi_exporter`. By extending this package, we can fix
that bug in `unifi_exporter`.